### PR TITLE
ignore global constructs like Math, Object, Array, JSON, & Date

### DIFF
--- a/example.js
+++ b/example.js
@@ -12,16 +12,16 @@ function test(str, prefix) {
   }
 }
 
-test('~ret.indexOf(arr[i])');
+test('~ret.indexOf(arr[i])')
 
-test('name.first + name.last');
+test('name.first + name.last')
 
-test('file.mime.split("/")');
+test('file.mime.split("/")')
 
-test('file.type + " " + classes().join(" ")');
+test('file.type + " " + classes().join(" ")')
 
-test('name.first + name.last() + last()', '$.');
+test('name.first + name.last() + last()', '$.')
 
-test('something()', '$.');
+test('something()', '$.')
 
-test('Math.random(first)', '$.');
+test('Math.random() + Math.round(n)', '$.')

--- a/example.js
+++ b/example.js
@@ -12,14 +12,16 @@ function test(str, prefix) {
   }
 }
 
-test('~ret.indexOf(arr[i])')
+test('~ret.indexOf(arr[i])');
 
-test('name.first + name.last')
+test('name.first + name.last');
 
-test('file.mime.split("/")')
+test('file.mime.split("/")');
 
-test('file.type + " " + classes().join(" ")')
+test('file.type + " " + classes().join(" ")');
 
 test('name.first + name.last() + last()', '$.');
 
-test('something()', '$.')
+test('something()', '$.');
+
+test('Math.random(first)', '$.');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
+/**
+ * Global Names
+ */
+
+var globals = /\b(Array|Date|Object|Math|JSON)\b/g;
 
 /**
  * Return immediate identifiers parsed from `str`.
@@ -26,6 +31,7 @@ module.exports = function(str, fn){
 function props(str) {
   return str
     .replace(/\.\w+|\w+ *\(|"[^"]*"|'[^']*'|\/([^/]+)\//g, '')
+    .replace(globals, '')
     .match(/[a-zA-Z_]\w*/g)
     || [];
 }
@@ -75,5 +81,5 @@ function unique(arr) {
 function prefixed(str) {
   return function(_){
     return str + _;
-  }
+  };
 }

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -16,8 +16,8 @@ describe('props(str, prefix)', function(){
   })
 
   it('should ignore global constructs', function(){
-    props('Math.random(num) * JSON.stringify(blob)', '$.')
-    .should.equal('Math.random($.num) * JSON.stringify($.blob)');
+    props('Math.round(n) * JSON.stringify(blob)', '$.')
+    .should.equal('Math.round($.n) * JSON.stringify($.blob)');
   })
 })
 

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -14,6 +14,11 @@ describe('props(str, prefix)', function(){
     props('first() + last() + classes.join()', '$.')
     .should.equal('$.first() + $.last() + $.classes.join()');
   })
+
+  it('should ignore global constructs', function(){
+    props('Math.random(num) * JSON.stringify(blob)', '$.')
+    .should.equal('Math.random($.num) * JSON.stringify($.blob)');
+  })
 })
 
 describe('props(str, fn)', function(){


### PR DESCRIPTION
Before:

``` js
props('Math.round(n) + JSON.stringify(blob)', '$.') 
// $.Math.round($.n) + $.JSON.stringify($.blob)
```

Now:

``` js
props('Math.round(n) + JSON.stringify(blob)', '$.') 
// Math.round($.n) + JSON.stringify($.blob)
```

---

I didn't add an exhaustive list, but this should get it started. A good list is at: [MDN: Javascript Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference). I can add them all, but I figured these were the most common ones that would come through.
